### PR TITLE
Added support for OAS Data Types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # hydra-openapi-parser
-This library contains the OpenAPI parser implemntaion in Python to be used with hydrus and python-hydra-agent.
+This library contains the OpenAPI parser implemntaion in Python to be used with `hydrus` and `hydra-python-agent`.
 
 Currently the library consists of openapi_parser module which helps hydrus parse OpenAPI standard docs.
 

--- a/samples/hydra_doc_sample.py
+++ b/samples/hydra_doc_sample.py
@@ -1,0 +1,719 @@
+"""
+Generated API Documentation for Server API using
+                server_doc_gen.py."""
+
+doc = {
+    "@context": {
+        "ApiDocumentation": "hydra:ApiDocumentation",
+        "description": "hydra:description",
+        "domain": {
+            "@id": "rdfs:domain",
+            "@type": "@id"
+        },
+        "expects": {
+            "@id": "hydra:expects",
+            "@type": "@id"
+        },
+        "hydra": "http://www.w3.org/ns/hydra/core#",
+        "label": "rdfs:label",
+        "method": "hydra:method",
+        "possibleStatus": "hydra:possibleStatus",
+        "property": {
+            "@id": "hydra:property",
+            "@type": "@id"
+        },
+        "range": {
+            "@id": "rdfs:range",
+            "@type": "@id"
+        },
+        "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+        "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+        "readonly": "hydra:readonly",
+        "required": "hydra:required",
+        "returns": {
+            "@id": "hydra:returns",
+            "@type": "@id"
+        },
+        "statusCode": "hydra:statusCode",
+        "statusCodes": "hydra:statusCodes",
+        "subClassOf": {
+            "@id": "rdfs:subClassOf",
+            "@type": "@id"
+        },
+        "supportedClass": "hydra:supportedClass",
+        "supportedOperation": "hydra:supportedOperation",
+        "supportedProperty": "hydra:supportedProperty",
+        "title": "hydra:title",
+        "vocab": "http://petstore.swagger.io/v2/vocab#",
+        "writeonly": "hydra:writeonly"
+    },
+    "@id": "http://petstore.swagger.io/v2/vocab",
+    "@type": "ApiDocumentation",
+    "description": "This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.",
+    "possibleStatus": [],
+    "supportedClass": [
+        {
+            "@id": "vocab:Pet",
+            "@type": "hydra:Class",
+            "description": "Pet",
+            "supportedOperation": [
+                {
+                    "@type": "http://schema.org/UpdateAction",
+                    "expects": "vocab:Pet",
+                    "method": "POST",
+                    "possibleStatus": [
+                        {
+                            "description": "Invalid input",
+                            "statusCode": 405
+                        }
+                    ],
+                    "returns": "null",
+                    "title": "Add a new pet to the store"
+                },
+                {
+                    "@type": "http://schema.org/AddAction",
+                    "expects": "vocab:Pet",
+                    "method": "PUT",
+                    "possibleStatus": [
+                        {
+                            "description": "Invalid ID supplied",
+                            "statusCode": 400
+                        }
+                    ],
+                    "returns": "null",
+                    "title": "Update an existing pet"
+                },
+                {
+                    "@type": "http://schema.org/FindAction",
+                    "expects": "https://schema.org/Text",
+                    "method": "GET",
+                    "possibleStatus": [
+                        {
+                            "description": "successful operation",
+                            "statusCode": 200
+                        }
+                    ],
+                    "returns": "vocab:Pet",
+                    "title": "get all pets"
+                }
+            ],
+            "supportedProperty": [
+                {
+                    "@type": "SupportedProperty",
+                    "property": "",
+                    "readonly": "true",
+                    "required": "false",
+                    "title": "id",
+                    "writeonly": "true"
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "",
+                    "readonly": "true",
+                    "required": "false",
+                    "title": "category",
+                    "writeonly": "true"
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "",
+                    "readonly": "true",
+                    "required": "true",
+                    "title": "name",
+                    "writeonly": "true"
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "",
+                    "readonly": "true",
+                    "required": "true",
+                    "title": "photoUrls",
+                    "writeonly": "true"
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "",
+                    "readonly": "true",
+                    "required": "false",
+                    "title": "tags",
+                    "writeonly": "true"
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "",
+                    "readonly": "true",
+                    "required": "false",
+                    "title": "status",
+                    "writeonly": "true"
+                }
+            ],
+            "title": "Pet"
+        },
+        {
+            "@id": "vocab:ApiResponse",
+            "@type": "hydra:Class",
+            "description": "ApiResponse",
+            "supportedOperation": [
+                {
+                    "@type": "http://schema.org/UpdateAction",
+                    "expects": "https://schema.org/Text",
+                    "method": "POST",
+                    "possibleStatus": [
+                        {
+                            "description": "successful operation",
+                            "statusCode": 200
+                        }
+                    ],
+                    "returns": "vocab:ApiResponse",
+                    "title": "uploads an image"
+                }
+            ],
+            "supportedProperty": [
+                {
+                    "@type": "SupportedProperty",
+                    "property": "",
+                    "readonly": "true",
+                    "required": "false",
+                    "title": "code",
+                    "writeonly": "true"
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "",
+                    "readonly": "true",
+                    "required": "false",
+                    "title": "type",
+                    "writeonly": "true"
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "",
+                    "readonly": "true",
+                    "required": "false",
+                    "title": "message",
+                    "writeonly": "true"
+                }
+            ],
+            "title": "ApiResponse"
+        },
+        {
+            "@id": "vocab:User",
+            "@type": "hydra:Class",
+            "description": "User",
+            "supportedOperation": [
+                {
+                    "@type": "http://schema.org/UpdateAction",
+                    "expects": "vocab:User",
+                    "method": "POST",
+                    "possibleStatus": [
+                        {
+                            "description": "Successful Operation",
+                            "statusCode": 200
+                        }
+                    ],
+                    "returns": "null",
+                    "title": "Create user"
+                },
+                {
+                    "@type": "http://schema.org/FindAction",
+                    "expects": "https://schema.org/Text",
+                    "method": "GET",
+                    "possibleStatus": [
+                        {
+                            "description": "successful operation",
+                            "statusCode": 200
+                        },
+                        {
+                            "description": "Invalid username supplied",
+                            "statusCode": 400
+                        },
+                        {
+                            "description": "User not found",
+                            "statusCode": 404
+                        }
+                    ],
+                    "returns": "vocab:User",
+                    "title": "Get user by user name"
+                },
+                {
+                    "@type": "http://schema.org/AddAction",
+                    "expects": "vocab:User",
+                    "method": "PUT",
+                    "possibleStatus": [
+                        {
+                            "description": "Invalid user supplied",
+                            "statusCode": 400
+                        }
+                    ],
+                    "returns": "null",
+                    "title": "Updated user"
+                }
+            ],
+            "supportedProperty": [
+                {
+                    "@type": "SupportedProperty",
+                    "property": "",
+                    "readonly": "true",
+                    "required": "false",
+                    "title": "id",
+                    "writeonly": "true"
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "",
+                    "readonly": "true",
+                    "required": "false",
+                    "title": "username",
+                    "writeonly": "true"
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "",
+                    "readonly": "true",
+                    "required": "false",
+                    "title": "firstName",
+                    "writeonly": "true"
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "",
+                    "readonly": "true",
+                    "required": "false",
+                    "title": "lastName",
+                    "writeonly": "true"
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "",
+                    "readonly": "true",
+                    "required": "false",
+                    "title": "email",
+                    "writeonly": "true"
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "",
+                    "readonly": "true",
+                    "required": "false",
+                    "title": "password",
+                    "writeonly": "true"
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "",
+                    "readonly": "true",
+                    "required": "false",
+                    "title": "phone",
+                    "writeonly": "true"
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "",
+                    "readonly": "true",
+                    "required": "false",
+                    "title": "userStatus",
+                    "writeonly": "true"
+                }
+            ],
+            "title": "User"
+        },
+        {
+            "@id": "vocab:Order",
+            "@type": "hydra:Class",
+            "description": "this is def",
+            "supportedOperation": [
+                {
+                    "@type": "http://schema.org/UpdateAction",
+                    "expects": "vocab:Order",
+                    "method": "POST",
+                    "possibleStatus": [
+                        {
+                            "description": "successful operation",
+                            "statusCode": 200
+                        },
+                        {
+                            "description": "Invalid Order",
+                            "statusCode": 400
+                        }
+                    ],
+                    "returns": "vocab:Order",
+                    "title": "Place an order for a pet"
+                },
+                {
+                    "@type": "http://schema.org/FindAction",
+                    "expects": "https://schema.org/Integer",
+                    "method": "GET",
+                    "possibleStatus": [
+                        {
+                            "description": "successful operation",
+                            "statusCode": 200
+                        },
+                        {
+                            "description": "Invalid ID supplied",
+                            "statusCode": 400
+                        },
+                        {
+                            "description": "Order not found",
+                            "statusCode": 404
+                        }
+                    ],
+                    "returns": "vocab:Order",
+                    "title": "Find purchase order by ID"
+                }
+            ],
+            "supportedProperty": [
+                {
+                    "@type": "SupportedProperty",
+                    "property": "",
+                    "readonly": "true",
+                    "required": "false",
+                    "title": "id",
+                    "writeonly": "true"
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "",
+                    "readonly": "true",
+                    "required": "false",
+                    "title": "petId",
+                    "writeonly": "true"
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "",
+                    "readonly": "true",
+                    "required": "false",
+                    "title": "quantity",
+                    "writeonly": "true"
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "",
+                    "readonly": "true",
+                    "required": "false",
+                    "title": "shipDate",
+                    "writeonly": "true"
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "",
+                    "readonly": "true",
+                    "required": "false",
+                    "title": "status",
+                    "writeonly": "true"
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "",
+                    "readonly": "true",
+                    "required": "false",
+                    "title": "complete",
+                    "writeonly": "true"
+                }
+            ],
+            "title": "Order"
+        },
+        {
+            "@id": "http://www.w3.org/ns/hydra/core#Collection",
+            "@type": "hydra:Class",
+            "description": "null",
+            "supportedOperation": [],
+            "supportedProperty": [
+                {
+                    "@type": "SupportedProperty",
+                    "property": "http://www.w3.org/ns/hydra/core#member",
+                    "readonly": "false",
+                    "required": "null",
+                    "title": "members",
+                    "writeonly": "false"
+                }
+            ],
+            "title": "Collection"
+        },
+        {
+            "@id": "http://www.w3.org/ns/hydra/core#Resource",
+            "@type": "hydra:Class",
+            "description": "null",
+            "supportedOperation": [],
+            "supportedProperty": [],
+            "title": "Resource"
+        },
+        {
+            "@id": "vocab:PetCollection",
+            "@type": "hydra:Class",
+            "description": "A collection of pet",
+            "subClassOf": "http://www.w3.org/ns/hydra/core#Collection",
+            "supportedOperation": [
+                {
+                    "@id": "_:pet_collection_retrieve",
+                    "@type": "http://schema.org/FindAction",
+                    "description": "Retrieves all Pet entities",
+                    "expects": "null",
+                    "method": "GET",
+                    "returns": "vocab:PetCollection",
+                    "statusCodes": []
+                },
+                {
+                    "@id": "_:pet_create",
+                    "@type": "http://schema.org/AddAction",
+                    "description": "Create new Pet entitity",
+                    "expects": "vocab:Pet",
+                    "method": "PUT",
+                    "returns": "vocab:Pet",
+                    "statusCodes": [
+                        {
+                            "description": "If the Pet entity was createdsuccessfully.",
+                            "statusCode": 201
+                        }
+                    ]
+                }
+            ],
+            "supportedProperty": [
+                {
+                    "@type": "SupportedProperty",
+                    "description": "The pet",
+                    "property": "http://www.w3.org/ns/hydra/core#member",
+                    "readonly": "false",
+                    "required": "false",
+                    "title": "members",
+                    "writeonly": "false"
+                }
+            ],
+            "title": "PetCollection"
+        },
+        {
+            "@id": "vocab:UserCollection",
+            "@type": "hydra:Class",
+            "description": "A collection of user",
+            "subClassOf": "http://www.w3.org/ns/hydra/core#Collection",
+            "supportedOperation": [
+                {
+                    "@id": "_:user_collection_retrieve",
+                    "@type": "http://schema.org/FindAction",
+                    "description": "Retrieves all User entities",
+                    "expects": "null",
+                    "method": "GET",
+                    "returns": "vocab:UserCollection",
+                    "statusCodes": []
+                },
+                {
+                    "@id": "_:user_create",
+                    "@type": "http://schema.org/AddAction",
+                    "description": "Create new User entitity",
+                    "expects": "vocab:User",
+                    "method": "PUT",
+                    "returns": "vocab:User",
+                    "statusCodes": [
+                        {
+                            "description": "If the User entity was createdsuccessfully.",
+                            "statusCode": 201
+                        }
+                    ]
+                }
+            ],
+            "supportedProperty": [
+                {
+                    "@type": "SupportedProperty",
+                    "description": "The user",
+                    "property": "http://www.w3.org/ns/hydra/core#member",
+                    "readonly": "false",
+                    "required": "false",
+                    "title": "members",
+                    "writeonly": "false"
+                }
+            ],
+            "title": "UserCollection"
+        },
+        {
+            "@id": "vocab:EntryPoint",
+            "@type": "hydra:Class",
+            "description": "The main entry point or homepage of the API.",
+            "supportedOperation": [
+                {
+                    "@id": "_:entry_point",
+                    "@type": "http://schema.org/FindAction",
+                    "description": "The APIs main entry point.",
+                    "expects": "null",
+                    "method": "GET",
+                    "returns": "null",
+                    "statusCodes": "vocab:EntryPoint"
+                }
+            ],
+            "supportedProperty": [
+                {
+                    "hydra:description": "The ApiResponse Class",
+                    "hydra:title": "apiresponse",
+                    "property": {
+                        "@id": "vocab:EntryPoint/pet/uploadImage",
+                        "@type": "hydra:Link",
+                        "description": "ApiResponse",
+                        "domain": "vocab:EntryPoint",
+                        "label": "ApiResponse",
+                        "range": "vocab:ApiResponse",
+                        "supportedOperation": [
+                            {
+                                "@id": "uploads an image",
+                                "@type": "http://schema.org/UpdateAction",
+                                "description": "null",
+                                "expects": "https://schema.org/Text",
+                                "label": "uploads an image",
+                                "method": "POST",
+                                "returns": "vocab:ApiResponse",
+                                "statusCodes": [
+                                    {
+                                        "description": "successful operation",
+                                        "statusCode": 200
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    "readonly": "true",
+                    "required": "null",
+                    "writeonly": "false"
+                },
+                {
+                    "hydra:description": "The Order Class",
+                    "hydra:title": "order",
+                    "property": {
+                        "@id": "vocab:EntryPoint/store/order",
+                        "@type": "hydra:Link",
+                        "description": "this is def",
+                        "domain": "vocab:EntryPoint",
+                        "label": "Order",
+                        "range": "vocab:Order",
+                        "supportedOperation": [
+                            {
+                                "@id": "place an order for a pet",
+                                "@type": "http://schema.org/UpdateAction",
+                                "description": "null",
+                                "expects": "vocab:Order",
+                                "label": "Place an order for a pet",
+                                "method": "POST",
+                                "returns": "vocab:Order",
+                                "statusCodes": [
+                                    {
+                                        "description": "successful operation",
+                                        "statusCode": 200
+                                    },
+                                    {
+                                        "description": "Invalid Order",
+                                        "statusCode": 400
+                                    }
+                                ]
+                            },
+                            {
+                                "@id": "find purchase order by id",
+                                "@type": "http://schema.org/FindAction",
+                                "description": "null",
+                                "expects": "https://schema.org/Integer",
+                                "label": "Find purchase order by ID",
+                                "method": "GET",
+                                "returns": "vocab:Order",
+                                "statusCodes": [
+                                    {
+                                        "description": "successful operation",
+                                        "statusCode": 200
+                                    },
+                                    {
+                                        "description": "Invalid ID supplied",
+                                        "statusCode": 400
+                                    },
+                                    {
+                                        "description": "Order not found",
+                                        "statusCode": 404
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    "readonly": "true",
+                    "required": "null",
+                    "writeonly": "false"
+                },
+                {
+                    "hydra:description": "The PetCollection collection",
+                    "hydra:title": "petcollection",
+                    "property": {
+                        "@id": "vocab:EntryPoint/pet",
+                        "@type": "hydra:Link",
+                        "description": "The PetCollection collection",
+                        "domain": "vocab:EntryPoint",
+                        "label": "PetCollection",
+                        "range": "vocab:PetCollection",
+                        "supportedOperation": [
+                            {
+                                "@id": "_:pet_collection_retrieve",
+                                "@type": "http://schema.org/FindAction",
+                                "description": "Retrieves all Pet entities",
+                                "expects": "null",
+                                "method": "GET",
+                                "returns": "vocab:PetCollection",
+                                "statusCodes": []
+                            },
+                            {
+                                "@id": "_:pet_create",
+                                "@type": "http://schema.org/AddAction",
+                                "description": "Create new Pet entitity",
+                                "expects": "vocab:Pet",
+                                "method": "PUT",
+                                "returns": "vocab:Pet",
+                                "statusCodes": [
+                                    {
+                                        "description": "If the Pet entity was createdsuccessfully.",
+                                        "statusCode": 201
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    "readonly": "true",
+                    "required": "null",
+                    "writeonly": "false"
+                },
+                {
+                    "hydra:description": "The UserCollection collection",
+                    "hydra:title": "usercollection",
+                    "property": {
+                        "@id": "vocab:EntryPoint/user",
+                        "@type": "hydra:Link",
+                        "description": "The UserCollection collection",
+                        "domain": "vocab:EntryPoint",
+                        "label": "UserCollection",
+                        "range": "vocab:UserCollection",
+                        "supportedOperation": [
+                            {
+                                "@id": "_:user_collection_retrieve",
+                                "@type": "http://schema.org/FindAction",
+                                "description": "Retrieves all User entities",
+                                "expects": "null",
+                                "method": "GET",
+                                "returns": "vocab:UserCollection",
+                                "statusCodes": []
+                            },
+                            {
+                                "@id": "_:user_create",
+                                "@type": "http://schema.org/AddAction",
+                                "description": "Create new User entitity",
+                                "expects": "vocab:User",
+                                "method": "PUT",
+                                "returns": "vocab:User",
+                                "statusCodes": [
+                                    {
+                                        "description": "If the User entity was createdsuccessfully.",
+                                        "statusCode": 201
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    "readonly": "true",
+                    "required": "null",
+                    "writeonly": "false"
+                }
+            ],
+            "title": "EntryPoint"
+        }
+    ],
+    "title": "Swagger Petstore"
+}


### PR DESCRIPTION
<!-- Please create/claim an issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->
Fixes #14 

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.5.2 and above.

### Description
<!-- Describe about what this PR does, previous state and new state of the output -->
Previously the Parser was unable to parse the basic OAS Data Types and what would happen that it would parse to a invalid parameter, making it not possible to dump the hydra_doc. 

After studying the Parser and understanding it and where the problem was different solutions could be proposed: ignore these endpoints, set empty parameters or, as the one I'm proposing in this pull request, is to assign the respective schema to the OAS Data Types.

### Change logs
Added support for OAS Data Types
Now the sample is being successfully parsed

<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->


<!-- #### Changed -->
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
<!-- - Change 1 -->


#### Fixed
<!-- Edit these points below to describe the bug fixes made with this PR -->
Creation of invalid input parameters


<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->
